### PR TITLE
Add project-manager skill

### DIFF
--- a/skills/project-manager/SKILL.md
+++ b/skills/project-manager/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: project-manager
+description: Manage and provide context for all projects under ~/code. Use when working across multiple projects, integrating projects together, checking project status, adding new projects, or when any task references code/builds/configs from existing projects. Triggers on questions about project structure, dependencies, build status, or cross-project integration (e.g., "rebuild X and update Y", "what projects do I have", "add a new module to X").
+metadata: {"openclaw":{"emoji":"📂","requires":{"anyBins":["bash","git"]}}}
+---
+
+# Project Manager
+
+Provides awareness of all user projects, their structure, dependencies, and integration points.
+
+## Project Location
+
+All projects live under **`~/code/`**.
+
+If your projects are stored elsewhere, symlink them (or the parent folder) into `~/code/`:
+
+```bash
+# Symlink an individual project
+ln -s /path/to/my-project ~/code/my-project
+
+# Symlink only the projects you want managed
+ln -s /data/work/api-server ~/code/api-server
+ln -s /data/work/frontend ~/code/frontend
+```
+
+This way you control exactly which projects the skill is aware of.
+
+## Discovery
+
+### Scan all projects
+```bash
+bash scripts/project-scan.sh
+```
+Scans `~/code` for projects, detects agent files (AGENTS.md, CLAUDE.md, CURSOR.md), shows git status, key build files, and disk usage.
+
+### Learning about a project
+When you encounter a new project or need deeper context:
+1. Run `scripts/project-scan.sh` to get a live snapshot
+2. Read the project's agent file (`AGENTS.md`, `CLAUDE.md`, `CURSOR.md`) and `README.md`
+3. Examine key build files (`Makefile`, `CMakeLists.txt`, `package.json`, etc.)
+4. Store what you learn in your memory (see below)
+
+## Memory
+
+Project knowledge lives in your **agent memory**, not in this skill's files.
+
+### Where to store project context
+- **`MEMORY.md`** → Curated project index: what each project is, its stack, key paths, status, and lessons learned
+- **`memory/YYYY-MM-DD.md`** → Daily notes about project work, build results, issues encountered
+
+### What to remember about each project
+- Type and purpose
+- Stack (languages, frameworks, databases)
+- Key paths (source, build output, configs)
+- Current status (working, broken, in-progress)
+- Important lessons or gotchas
+
+### What to remember about project relationships
+- Which projects depend on each other
+- Integration patterns (e.g., "when A is rebuilt, B's artifacts must be regenerated")
+- Shared resources (databases, configs, services)
+
+### Keeping it fresh
+- After significant project work, update your memory with new findings
+- When a project's status changes, reflect that in MEMORY.md
+- Periodically re-run the scan to catch new projects or changes
+
+## Per-Project Context
+
+Projects use standard agent files for in-project context:
+- `AGENTS.md` / `CLAUDE.md` / `CURSOR.md` — read these when working inside a specific project
+- `README.md` — general project documentation
+
+When working on a task that touches a project, read its agent file for project-specific conventions and context.
+
+## Workflows
+
+### Adding a New Project
+1. Create or symlink the project directory under `~/code/`
+2. Add an `AGENTS.md` or similar agent file with project context
+3. Run the scan to verify detection
+4. Update MEMORY.md with the new project's details
+5. If it relates to existing projects, document the dependency in MEMORY.md
+
+### Cross-Project Integration
+When a task involves multiple projects:
+1. Check your memory for known dependencies and integration patterns
+2. Read agent files from each involved project for specific context
+3. Follow documented integration patterns
+4. After changes, verify downstream projects still work
+5. Update memory with any new integration lessons
+
+### Checking Project Status
+Run `scripts/project-scan.sh` to get a live snapshot of all projects including git status and dirty files.

--- a/skills/project-manager/scripts/project-scan.sh
+++ b/skills/project-manager/scripts/project-scan.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Scan all projects and output structured info
+# Usage: project-scan.sh [base_dir...]
+# Defaults to ~/code if no args given
+
+set -euo pipefail
+
+DIRS=("${@:-$HOME/code}")
+
+for BASE in ${DIRS[@]}; do
+  [ -d "$BASE" ] || continue
+  for PROJECT in "$BASE"/*/; do
+    [ -d "$PROJECT" ] || continue
+    NAME=$(basename "$PROJECT")
+
+    echo "=== $BASE/$NAME ==="
+
+    # Agent files (AGENTS.md, CLAUDE.md, CURSOR.md, README.md)
+    for f in AGENTS.md CLAUDE.md CURSOR.md README.md; do
+      if [ -f "$PROJECT/$f" ]; then
+        echo "  [agent-file] $f"
+      fi
+    done
+
+    # Git info
+    if [ -d "$PROJECT/.git" ]; then
+      BRANCH=$(git -C "$PROJECT" branch --show-current 2>/dev/null || echo "unknown")
+      LAST_COMMIT=$(git -C "$PROJECT" log -1 --format="%h %s (%cr)" 2>/dev/null || echo "unknown")
+      DIRTY=$(git -C "$PROJECT" status --porcelain 2>/dev/null | wc -l)
+      echo "  git_branch: $BRANCH"
+      echo "  git_last_commit: $LAST_COMMIT"
+      echo "  git_dirty_files: $DIRTY"
+    fi
+
+    # Key files (build systems, configs)
+    echo "  key_files:"
+    for f in Makefile CMakeLists.txt package.json Cargo.toml go.mod setup.py pyproject.toml docker-compose.yml Dockerfile; do
+      [ -f "$PROJECT/$f" ] && echo "    - $f"
+    done
+
+    # Size
+    SIZE=$(du -sh "$PROJECT" 2>/dev/null | cut -f1)
+    echo "  disk_size: $SIZE"
+    echo ""
+  done
+done


### PR DESCRIPTION
Adds the **project-manager** skill for managing and discovering projects across `~/code` and `~/linux`.

## What's included

- **SKILL.md** — Skill definition with workflows for adding projects, cross-project integration, and status checks
- **scripts/project-scan.sh** — Auto-discovers projects, detects agent files, shows git status, build systems, and disk usage
- **references/registry.md** — Template for curating a project index
- **references/dependencies.md** — Template for mapping cross-project dependencies

## Design decisions

- References are **blank templates** with examples rather than hardcoded data — the scan script handles live discovery, and users fill in the curated context as they go
- Requires only `bash` and `git` (no exotic dependencies)