### PR TITLE
fix: resolve octoRest error in OpenCode workflow

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -1,8 +1,8 @@
 name: OpenCode Agent
 
 on:
-  issues:
-    types: [labeled]
+  issue_comment:
+    types: [created]
 
 concurrency:
   group: opencode-agent
@@ -11,14 +11,16 @@ concurrency:
 jobs:
   opencode:
     if: >-
-      github.event.label.name == 'Ready for agent' &&
+      (
+        contains(github.event.comment.body, '/opencode') ||
+        contains(github.event.comment.body, '/oc')
+      ) &&
       (
         github.event.sender.login == github.repository_owner ||
         contains(fromJSON('["heydemoura", "m3dabot"]'), github.event.sender.login)
       )
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
       contents: write
       pull-requests: write
       issues: write
@@ -35,16 +37,18 @@ jobs:
 
       - name: Run OpenCode
         uses: anomalyco/opencode/github@latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           model: github-copilot/claude-opus-4-5
+          use_github_token: true
           prompt: |
             You are working on the ai-skills-inventory repository — a curated collection of
-            agent-agnostic AI skills following the AgentSkills spec.
+            agent-agnostic AI skills and agents following the AgentSkills spec.
 
-            Read the issue below carefully. Implement what is requested:
-            - Create or modify skill folders under `skills/`
-            - Each skill must have a `SKILL.md` with proper YAML frontmatter (name, description, metadata)
-            - Include `scripts/` and/or `references/` subdirectories as needed
-            - Follow the patterns of existing skills in this repo
+            Read the issue thread carefully. Implement what is requested:
+            - For skills: create or modify folders under `skills/` with `SKILL.md` + optional `scripts/` and `references/`
+            - For agents: create or modify folders under `agents/` with `AGENT.md`
+            - Follow the patterns and format of existing skills/agents in this repo
 
             When done, create a PR with all changes. Reference the issue number in the PR description.


### PR DESCRIPTION
## Problem

The OpenCode workflow was failing with:
```
undefined is not an object (evaluating 'octoRest.rest')
```

## Root Cause

Two issues:

1. **Wrong trigger type** — The workflow used `issues.labeled` but the OpenCode GitHub Action (`opencode github run`) expects **comment-based events** (`issue_comment` or `pull_request_review_comment`). It parses the comment body for commands.

2. **OIDC token exchange failure** — Using `id-token: write` for OIDC auth requires the OpenCode GitHub App to be installed. Without it, the Octokit client fails to initialize.

## Fix

- **Trigger**: Changed from `issues.labeled` to `issue_comment.created` — now triggers when someone comments `/opencode` or `/oc` on an issue or PR
- **Auth**: Use `GITHUB_TOKEN` directly via `use_github_token: true` — skips OIDC entirely, uses the built-in Actions token
- **Removed** `id-token: write` permission (no longer needed)
- **Kept** sender allowlist guardrail (heydemoura, m3dabot, repo owner)
- **Updated** prompt to cover both skills and agents

## Usage

Comment on any issue or PR:
```
/opencode fix this
```
or
```
/oc implement the feature described above
```