### PR TITLE
fix: use Copilot OIDC for github-copilot model access

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -21,6 +21,7 @@ jobs:
       )
     runs-on: ubuntu-latest
     permissions:
+      id-token: write
       contents: write
       pull-requests: write
       issues: write
@@ -37,11 +38,8 @@ jobs:
 
       - name: Run OpenCode
         uses: anomalyco/opencode/github@latest
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           model: github-copilot/claude-opus-4-5
-          use_github_token: true
           prompt: |
             You are working on the ai-skills-inventory repository — a curated collection of
             agent-agnostic AI skills and agents following the AgentSkills spec.


### PR DESCRIPTION
## Problem

`ProviderModelNotFoundError` — the `github-copilot/claude-opus-4-5` model requires OIDC authentication via the OpenCode GitHub App. Using `GITHUB_TOKEN` directly doesn't have access to Copilot models.

## Fix

- Restored `id-token: write` permission for OIDC token exchange
- Removed `use_github_token: true` and `GITHUB_TOKEN` env
- This uses the Copilot Pro subscription via OIDC (no API key secrets needed)

## Prerequisite

**The [OpenCode GitHub App](https://github.com/apps/opencode-agent) must be installed on this repo** for the OIDC token exchange to work. Install it at: https://github.com/apps/opencode-agent