### PR TITLE
fix: use claude-opus-4-6 model (available on Copilot Pro)

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Run OpenCode
         uses: anomalyco/opencode/github@latest
         with:
-          model: github-copilot/claude-opus-4-5
+          model: github-copilot/claude-opus-4-6
           prompt: |
             You are working on the ai-skills-inventory repository — a curated collection of
             agent-agnostic AI skills and agents following the AgentSkills spec.


### PR DESCRIPTION
Changes `github-copilot/claude-opus-4-5` → `github-copilot/claude-opus-4-6` which is supported on Copilot Pro.